### PR TITLE
Remove parameter check from each iteration

### DIFF
--- a/src/ArrayDiffMultidimensional.php
+++ b/src/ArrayDiffMultidimensional.php
@@ -6,9 +6,9 @@ class ArrayDiffMultidimensional
 {
 
     /**
-     * Returns an array with the differences between $array1 and $array2.
-     * Compares array1 against one or more other arrays and returns the values in array1
-     * that are not present in any of the other arrays.
+     * Returns an array with items that are present in first array,
+     * but not in the second one. If second argument is not
+     * array first array is returned.
      * @param mixed $array1
      * @param mixed $array2
      * @return array

--- a/src/ArrayDiffMultidimensional.php
+++ b/src/ArrayDiffMultidimensional.php
@@ -6,18 +6,25 @@ class ArrayDiffMultidimensional
 {
 
     /**
-     * Returns an array with the differences between $array1 and $array2
-     *
-     * @param array $aArray1
-     * @param array $aArray2
+     * Returns an array with the differences between $array1 and $array2.
+     * Compares array1 against one or more other arrays and returns the values in array1
+     * that are not present in any of the other arrays.
+     * @param mixed $array1
+     * @param mixed $array2
      * @return array
+     * @internal param array $aArray1
+     * @internal param array $aArray2
      */
     public static function compare($array1, $array2)
     {
         $result = array();
 
+        if (!is_array($array2)) {
+            return $array1;
+        }
+
         foreach ($array1 as $key => $value) {
-            if (!is_array($array2) || !array_key_exists($key, $array2)) {
+            if (!array_key_exists($key, $array2)) {
                 $result[$key] = $value;
                 continue;
             }

--- a/tests/ArrayCompareTest.php
+++ b/tests/ArrayCompareTest.php
@@ -78,4 +78,25 @@ class ArrayCompareTest extends \PHPUnit_Framework_TestCase
 		$this->assertEquals( count($this->diff->compare($new,$old)), 1 );
 		$this->assertTrue( isset($this->diff->compare($new,$old)['c']['f']) );
 	}
+
+    /** @test */
+    public function DifferenceFail()
+    {
+        $new = [
+            'a' => 'b',
+            'c' => [
+                'd' => 'e',
+            ],
+        ];
+
+        $old = [
+            'a' => 'b',
+            'c' => [
+                'd' => 'e',
+                'f' => uniqid(),
+            ],
+        ];
+
+        $this->assertNotEquals( 1, count($this->diff->compare($new,$old)) );
+    }
 }

--- a/tests/ArrayCompareTest.php
+++ b/tests/ArrayCompareTest.php
@@ -118,4 +118,21 @@ class ArrayCompareTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($old, $this->diff->compare($old, $new));
     }
+
+    /**
+     * @test
+     * @expectedException \PHPUnit_Framework_Error
+     */
+    public function FirstArgumentIsNotArray()
+    {
+        $old = null;
+        $new = [
+            'a' => 'b',
+            'c' => [
+                'd' => 'e',
+            ],
+        ];
+
+        $this->assertEquals($new, $this->diff->compare($old, $new));
+    }
 }

--- a/tests/ArrayCompareTest.php
+++ b/tests/ArrayCompareTest.php
@@ -118,21 +118,4 @@ class ArrayCompareTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($old, $this->diff->compare($old, $new));
     }
-
-    /**
-     * @test
-     * @expectedException \PHPUnit_Framework_Error
-     */
-    public function FirstArgumentIsNotArray()
-    {
-        $old = null;
-        $new = [
-            'a' => 'b',
-            'c' => [
-                'd' => 'e',
-            ],
-        ];
-
-        $this->assertEquals($new, $this->diff->compare($old, $new));
-    }
 }

--- a/tests/ArrayCompareTest.php
+++ b/tests/ArrayCompareTest.php
@@ -6,81 +6,81 @@ use Rogervila\ArrayDiffMultidimensional;
 
 class ArrayCompareTest extends \PHPUnit_Framework_TestCase
 {
-	protected $diff;
+    protected $diff;
 
-	public function setUp()
-	{
-		$this->diff = new ArrayDiffMultidimensional();
-	}
-
-	/** @test */
-	public function returnsAnArray()
-	{
-		$this->assertTrue( is_array($this->diff->compare([],[])) );
-	}
-
-	/** @test */
-	public function DetectsTheDifferenceOnStringValue()
-	{
-		$old = [
-			'a' => 'b',
-			'c' => uniqid(),
-		];
-
-		$new = [
-			'a' => 'b',
-			'c' => uniqid(),
-		];
-
-		$this->assertEquals( count($this->diff->compare($new,$old)), 1 );
-		$this->assertTrue( isset($this->diff->compare($new,$old)['c']) );
-	}
-
-	/** @test */
-	public function DetectsChangeFromStringToArray()
-	{
-		$new = [
-			'a' => 'b',
-			'c' => [
-				'd' => uniqid(),
-				'e' => uniqid(),
-			],
-		];
-
-		$old = [
-			'a' => 'b',
-			'c' => uniqid(),
-		];
-
-		$this->assertEquals( count($this->diff->compare($new,$old)), 1 );
-		$this->assertTrue( is_array($this->diff->compare($new,$old)['c']) );
-	}
-
-	/** @test */
-	public function DetectsChangesOnNestedArrays()
-	{
-		$new = [
-			'a' => 'b',
-			'c' => [
-				'd' => 'e',
-				'f' => uniqid(),
-			],
-		];
-
-		$old = [
-			'a' => 'b',
-			'c' => [
-				'd' => 'e',
-				'f' => uniqid(),
-			],
-		];
-
-		$this->assertEquals( count($this->diff->compare($new,$old)), 1 );
-		$this->assertTrue( isset($this->diff->compare($new,$old)['c']['f']) );
-	}
+    public function setUp()
+    {
+        $this->diff = new ArrayDiffMultidimensional();
+    }
 
     /** @test */
-    public function DifferenceFail()
+    public function returnsAnArray()
+    {
+        $this->assertTrue(is_array($this->diff->compare([], [])));
+    }
+
+    /** @test */
+    public function DetectsTheDifferenceOnStringValue()
+    {
+        $old = [
+            'a' => 'b',
+            'c' => uniqid(),
+        ];
+
+        $new = [
+            'a' => 'b',
+            'c' => uniqid(),
+        ];
+
+        $this->assertEquals(count($this->diff->compare($new, $old)), 1);
+        $this->assertTrue(isset($this->diff->compare($new, $old)['c']));
+    }
+
+    /** @test */
+    public function DetectsChangeFromStringToArray()
+    {
+        $new = [
+            'a' => 'b',
+            'c' => [
+                'd' => uniqid(),
+                'e' => uniqid(),
+            ],
+        ];
+
+        $old = [
+            'a' => 'b',
+            'c' => uniqid(),
+        ];
+
+        $this->assertEquals(count($this->diff->compare($new, $old)), 1);
+        $this->assertTrue(is_array($this->diff->compare($new, $old)['c']));
+    }
+
+    /** @test */
+    public function DetectsChangesOnNestedArrays()
+    {
+        $new = [
+            'a' => 'b',
+            'c' => [
+                'd' => 'e',
+                'f' => uniqid(),
+            ],
+        ];
+
+        $old = [
+            'a' => 'b',
+            'c' => [
+                'd' => 'e',
+                'f' => uniqid(),
+            ],
+        ];
+
+        $this->assertEquals(count($this->diff->compare($new, $old)), 1);
+        $this->assertTrue(isset($this->diff->compare($new, $old)['c']['f']));
+    }
+
+    /** @test */
+    public function BeAwareThatThisArrayAreEquals()
     {
         $new = [
             'a' => 'b',
@@ -97,6 +97,42 @@ class ArrayCompareTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $this->assertNotEquals( 1, count($this->diff->compare($new,$old)) );
+        $this->assertNotEquals(1, count($this->diff->compare($new, $old)));
+    }
+
+
+    /** @test */
+    public function SecondArgumentIsNotArray()
+    {
+        $old = [
+            'a' => 'b',
+            'c' => [
+                'd' => 'e',
+                'ff' => [
+                    'test'
+                ]
+            ],
+        ];
+
+        $new = 100;
+
+        $this->assertEquals($old, $this->diff->compare($old, $new));
+    }
+
+    /**
+     * @test
+     * @expectedException \PHPUnit_Framework_Error
+     */
+    public function FirstArgumentIsNotArray()
+    {
+        $old = null;
+        $new = [
+            'a' => 'b',
+            'c' => [
+                'd' => 'e',
+            ],
+        ];
+
+        $this->assertEquals($new, $this->diff->compare($old, $new));
     }
 }


### PR DESCRIPTION
- I removed the parameter check from each iteration.
- When second argument is not an array, the result is not build anymore, but function return first array which is the same.
- I've added two tests for cases when first or second argument is not array.
- I used 'Code reformat' in test file & somehow it rearranged, but tests are the same.