### PR TITLE
Add a .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.github export-ignore
+/.circleci export-ignore
+/tests export-ignore
+/.php_cs export-ignore
+/.styleci.yml export-ignore
+/.codeclimate.yml export-ignore
+/phpunit.xml export-ignore


### PR DESCRIPTION
This will lower the bundle size to only 3 files

```console
$ du -sh /home/williamdes/array-diff-multidimensional-master
188K	/home/williamdes/array-diff-multidimensional-master
$ du -sh /home/williamdes/array-diff-multidimensional-gitattrs
44K	/home/williamdes/array-diff-multidimensional-gitattrs
$ du -sh /home/williamdes/array-diff-multidimensional-master/*
12K	/home/williamdes/array-diff-multidimensional-master/composer.json
12K	/home/williamdes/array-diff-multidimensional-master/phpunit.xml
12K	/home/williamdes/array-diff-multidimensional-master/README.md
16K	/home/williamdes/array-diff-multidimensional-master/src
24K	/home/williamdes/array-diff-multidimensional-master/tests
$ du -sh /home/williamdes/array-diff-multidimensional-gitattrs/*
12K	/home/williamdes/array-diff-multidimensional-gitattrs/composer.json
12K	/home/williamdes/array-diff-multidimensional-gitattrs/README.md
16K	/home/williamdes/array-diff-multidimensional-gitattrs/src
```

`git archive HEAD --format zip --output=repo.zip`