### PR TITLE
array_diff_multidimensional helper function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,10 @@
   "autoload": {
     "psr-4": {
       "Rogervila\\": "src/"
-    }
+    },
+    "files": [
+      "src/helpers.php"
+    ]
   },
   "autoload-dev": {
     "psr-4": {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,21 @@
+<?php
+
+use Rogervila\ArrayDiffMultidimensional;
+
+if (!function_exists('array_diff_multidimensional')) {
+
+    /**
+     * Returns an array with the differences between $array1 and $array2
+     * $strict variable defines if comparison must be strict or not
+     *
+     * @param array $array1
+     * @param array $array2
+     * @param bool $strict
+     *
+     * @return array
+     */
+    function array_diff_multidimensional($array1, $array2, $strict = true)
+    {
+        return ArrayDiffMultidimensional::compare($array1, $array2, $strict);
+    }
+}

--- a/tests/HelperFunctionTest.php
+++ b/tests/HelperFunctionTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Rogervila\Test;
+
+use PHPUnit\Framework\TestCase;
+
+class HelperFunctionTest extends TestCase
+{
+    /** @test */
+    public function it_returns_an_array()
+    {
+        $this->assertTrue(is_array(array_diff_multidimensional([], [])));
+    }
+
+    /** @test */
+    public function loose_comparisons()
+    {
+        $new = [
+            'a' => 'b',
+            'c' => 288,
+        ];
+
+        $old = [
+            'a' => 'b',
+            'c' => '288',
+        ];
+
+        $this->assertEquals(0, count(array_diff_multidimensional($new, $old, false)));
+        $this->assertFalse(isset(array_diff_multidimensional($new, $old, false)['c']));
+    }
+
+    /** @test */
+    public function strict_comparisons()
+    {
+        $new = [
+            'a' => 'b',
+            'c' => 288,
+        ];
+
+        $old = [
+            'a' => 'b',
+            'c' => '288',
+        ];
+
+        $this->assertEquals(1, count(array_diff_multidimensional($new, $old)));
+        $this->assertTrue(isset(array_diff_multidimensional($new, $old)['c']));
+        $this->assertEquals(288, array_diff_multidimensional($new, $old)['c']);
+
+        $this->assertEquals(1, count(array_diff_multidimensional($new, $old, true)));
+        $this->assertTrue(isset(array_diff_multidimensional($new, $old, true)['c']));
+        $this->assertEquals(288, array_diff_multidimensional($new, $old, true)['c']);
+    }
+}


### PR DESCRIPTION
Adds a global `array_diff_multidimensional()` helper function.

```php
$new = [
	'a' => 'b',
	'c' => [
		'd' => 'e',
		'f' => 'Hello',
	],
];

$old = [
	'a' => 'b',
	'c' => [
		'd' => 'e',
		'f' => 'Goodbye',
	],
];

$result = array_diff_multidimensional($new, $old);

var_dump($result);

// [
// 	'c' => [
// 		'f' => 'Hello'
//  	],
// ]
```